### PR TITLE
Added seperate method for retrieving provinces, added empty default value

### DIFF
--- a/gravityforms-nl.php
+++ b/gravityforms-nl.php
@@ -220,23 +220,34 @@ class GravityFormsNL {
 			'country'     => __( 'Netherlands', 'gravityforms_nl' ),
 			'zip_label'   => __( 'Postal Code', 'gravityforms_nl' ),
 			'state_label' => __( 'Province', 'gravityforms_nl' ),
-			'states'      => array(
-				__( 'Drenthe', 'gravityforms_nl' ),
-				__( 'Flevoland', 'gravityforms_nl' ),
-				__( 'Friesland', 'gravityforms_nl' ),
-				__( 'Gelderland', 'gravityforms_nl' ),
-				__( 'Groningen', 'gravityforms_nl' ),
-				__( 'Limburg', 'gravityforms_nl' ),
-				__( 'Noord-Brabant', 'gravityforms_nl' ),
-				__( 'Noord-Holland', 'gravityforms_nl' ),
-				__( 'Overijssel', 'gravityforms_nl' ),
-				__( 'Utrecht', 'gravityforms_nl' ),
-				__( 'Zeeland', 'gravityforms_nl' ),
-				__( 'Zuid-Holland', 'gravityforms_nl' )
-			)
+			'states'      => array_merge(array(''), self::get_dutch_provinces())
 		);
 
 		return $address_types; 
+	}
+	
+	////////////////////////////////////////////////////////////
+	
+	/**
+	 * Get list of Dutch provinces
+	 * 
+	 * @return array
+	 */
+	public static function get_dutch_provinces() {
+		return array(
+			__( 'Drenthe', 'gravityforms_nl' ),
+			__( 'Flevoland', 'gravityforms_nl' ),
+			__( 'Friesland', 'gravityforms_nl' ),
+			__( 'Gelderland', 'gravityforms_nl' ),
+			__( 'Groningen', 'gravityforms_nl' ),
+			__( 'Limburg', 'gravityforms_nl' ),
+			__( 'Noord-Brabant', 'gravityforms_nl' ),
+			__( 'Noord-Holland', 'gravityforms_nl' ),
+			__( 'Overijssel', 'gravityforms_nl' ),
+			__( 'Utrecht', 'gravityforms_nl' ),
+			__( 'Zeeland', 'gravityforms_nl' ),
+			__( 'Zuid-Holland', 'gravityforms_nl' )
+		);	
 	}
 
 	////////////////////////////////////////////////////////////


### PR DESCRIPTION
The empty default value reflects the same behavior as is included by default in GravityForms. When hiding a province field for the frontend user, the province would still be submitted by email and thus, included in the {all_fields} merge tag, because there was no option to select an empty default.
