### PR TITLE
Added gform_datepicker_init

### DIFF
--- a/gravityforms-nl.php
+++ b/gravityforms-nl.php
@@ -191,8 +191,9 @@ class GravityFormsNLPlugin {
 			/**
 			 * gforms_ui_datepicker » @since ?
 			 * gforms_datepicker » @since Gravity Forms 1.7.5
+			 * gform_datepicker_init » @since Gravity Forms 1.8.9
 			 */
-			foreach ( array( 'gforms_ui_datepicker', 'gforms_datepicker' ) as $script_datepicker ) {
+			foreach ( array( 'gforms_ui_datepicker', 'gforms_datepicker', 'gform_datepicker_init' ) as $script_datepicker ) {
 				if ( wp_script_is( $script_datepicker ) ) {
 					// @see http://code.google.com/p/jquery-ui/source/browse/trunk/ui/i18n/jquery.ui.datepicker-nl.js
 					// @see https://github.com/jquery/jquery-ui/blob/master/ui/i18n/jquery.ui.datepicker-nl.js


### PR DESCRIPTION
Gravity Forms changed the script name from 'gform_datepicker' to 'gform_datepicker_init'. 
I am not 100% sure if they made the change in version 1.8.9. 
